### PR TITLE
Version 5.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,24 +22,35 @@ requirements:
 
   run:
     - python
-    - pytz
+    - backports.zoneinfo  # [py<39]
+    - tzdata  # [win]
 
 test:
   imports:
     - tzlocal
+  source_files:
+    - tests
   requires:
     - pip
+    - pytest
+    - pytest-mock
   commands:
     - pip check
 
+    {% set tests_to_skip = "_not_a_real_test" %}
+    # Skipping tests due to a symlinks error
+    # https://github.com/regebro/tzlocal/issues/146
+    {% set tests_to_skip = tests_to_skip + " or test_symlink_localtime or test_conflicting or test_noconflict" %}
+    - pytest tests -vv -k "not ({{ tests_to_skip }})"
+
 about:
   description: |
-    This Python module returns a tzinfo object (with a pytz_deprecation_shim, 
-    for pytz compatibility) with the local timezone information, 
+    This Python module returns a tzinfo object (with a pytz_deprecation_shim,
+    for pytz compatibility) with the local timezone information,
     under Unix and Windows.
   doc_source_url: https://github.com/regebro/tzlocal/tree/{{ version }}
   home: https://github.com/regebro/tzlocal
-  license: MIT 
+  license: MIT
   license_family: MIT
   license_file: LICENSE.txt
   summary: 'tzinfo object for the local timezone'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
   run:
     - python
     - backports.zoneinfo  # [py<39]
-    - tzdata  # [win]
+    - python-tzdata  # [win]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,8 @@ source:
   sha256: 8d399205578f1a9342816409cc1e46a93ebd5755e39ea2d85334bea911bf0e6e
 
 build:
-  number: 1
+  skip: true  # [py<38]
+  number: 0
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   skip: true  # [py<38]
   number: 0
-  script: python -m pip install --no-deps --ignore-installed .
+  script: python -m pip install --no-deps --ignore-installed . --no-build-isolation
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.1" %}
+{% set version = "5.2" %}
 
 package:
   name: tzlocal
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/t/tzlocal/tzlocal-{{ version }}.tar.gz
-  sha256: 643c97c5294aedc737780a49d9df30889321cbe1204eac2c2ec6134035a92e44
+  sha256: 8d399205578f1a9342816409cc1e46a93ebd5755e39ea2d85334bea911bf0e6e
 
 build:
   number: 1


### PR DESCRIPTION
tzlocal 5.2

**Destination channel:** defaults

### Links

- [PKG-4509](https://anaconda.atlassian.net/browse/PKG-4509)
- [Upstream repository](https://github.com/regebro/tzlocal/tree/5.2)
- [Upstream changelog/diff](https://github.com/regebro/tzlocal/blob/5.2/CHANGES.txt)

### Explanation of changes:
- Update version
- Skip python 3.7
- Update dependencies
- Add upstream tests
- Linter fixes


[PKG-4509]: https://anaconda.atlassian.net/browse/PKG-4509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ